### PR TITLE
fix: correct scope on slf4j backend

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
             <version>1.7.36</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Dependencies to slf4j backends must not be propagated to users of a library. This will create problems as slf4j only allows a single backend inside a JVM.